### PR TITLE
Fix: vars() argument must have __dict__ attribute.

### DIFF
--- a/buttersink/send.py
+++ b/buttersink/send.py
@@ -208,7 +208,7 @@ def replaceIDs(data, receivedUUID, receivedGen, parentUUID, parentGen):
         attrs[attrHeader.tlv_type] = attrData.readBuffer(attrHeader.tlv_len)
 
     def calcCRC():
-        header = vars(cmdHeader)
+        header = cmdHeader._asdict()
         header['crc'] = 0
 
         # This works, but is slow
@@ -256,7 +256,7 @@ def replaceIDs(data, receivedUUID, receivedGen, parentUUID, parentGen):
         crc = calcCRC()
         if cmdHeader.crc != crc:
             logger.debug("Correcting CRC from %d to %d", cmdHeader.crc, crc)
-            header = vars(cmdHeader)
+            header = cmdHeader._asdict()
             header['crc'] = crc
             cmdHeaderView[:] = btrfs_cmd_header.write(header).tostring()
 


### PR DESCRIPTION
On Centos 7.4 and Python 3.6 the default code spits two errors when trying buttersink btrfs:///mnt/local/volume btrfs:///mnt/iscsi/target compaling of empty vars list and
Error: vars() argument must have __dict__ attribute.
So changing these two lines in send.py from vars(cmdHeader) to cmdHeader._asdict() fixes the error.